### PR TITLE
Restore original socket after SOCKS proxy checks

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -19,6 +19,9 @@ from socks import set_default_proxy, SOCKS4, SOCKS5, socksocket
 from urllib3.exceptions import ProxyError, SSLError, ConnectTimeoutError, ReadTimeoutError, NewConnectionError
 import logging
 
+# Save the original socket to restore after proxy checks
+original_socket = socket.socket
+
 # Setup logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -135,7 +138,8 @@ def check_proxy(proxy, proxy_type):
         return None
     finally:
         socks.set_default_proxy()
-        socket.socket = socket.socket
+        # Restore the original socket to avoid affecting other connections
+        socket.socket = original_socket
     
     return None
 


### PR DESCRIPTION
## Summary
- Preserve the original `socket.socket` before patching for SOCKS proxy checks
- Restore the saved socket in `check_proxy` to prevent unintended proxying of later connections

## Testing
- `python -m py_compile proxy.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a3ca5364832ba0934bff6bff1155