### PR TITLE
Replace unreachable pubproxy source with alternative proxy list

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -38,4 +38,4 @@ https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/https_pr
 https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/socks4_proxies.txt
 https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/socks5_proxies.txt
 https://github.com/clarketm/proxy-list/blob/master/proxy-list-raw.txt
-http://pubproxy.com/api/proxy?limit=5&format=txt
+https://raw.githubusercontent.com/ShiftyTR/Proxy-List/master/proxy.txt


### PR DESCRIPTION
## Summary
- remove pubproxy API link that now returns `Domain forbidden`
- add ShiftyTR proxy list as a replacement source

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6895aa75a6b4832b941d4add62a3354c