### PR TITLE
Replace obsolete getproxy links with ShiftyTR sources

### DIFF
--- a/urls.txt
+++ b/urls.txt
@@ -29,10 +29,10 @@ https://github.com/prxchk/proxy-list/blob/main/http.txt
 https://github.com/prxchk/proxy-list/blob/main/socks4.txt
 https://github.com/prxchk/proxy-list/blob/main/socks5.txt
 https://github.com/saisuiu/Lionkings-Http-Proxys-Proxies/blob/main/free.txt
-https://github.com/ObcbO/getproxy/blob/master/http.txt
-https://github.com/ObcbO/getproxy/blob/master/https.txt
-https://github.com/ObcbO/getproxy/blob/master/socks4.txt
-https://github.com/ObcbO/getproxy/blob/master/socks5.txt
+https://github.com/ShiftyTR/Proxy-List/blob/master/http.txt
+https://github.com/ShiftyTR/Proxy-List/blob/master/https.txt
+https://github.com/ShiftyTR/Proxy-List/blob/master/socks4.txt
+https://github.com/ShiftyTR/Proxy-List/blob/master/socks5.txt
 https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/http_proxies.txt
 https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/https_proxies.txt
 https://github.com/Anonym0usWork1221/Free-Proxies/blob/main/proxy_files/socks4_proxies.txt


### PR DESCRIPTION
## Summary
- replace outdated getproxy entries with ShiftyTR/Proxy-List sources in `urls.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6895aa7eefbc832bb0c3b8596de1c27a